### PR TITLE
add MCP server badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,10 @@
 
 An MCP (Model Context Protocol) server that provides tools for searching and fetching openly-licensed images from [Openverse](https://openverse.org/).
 
+<a href="https://glama.ai/mcp/servers/@neno-is-ooo/mcp-openverse">
+  <img width="380" height="200" src="https://glama.ai/mcp/servers/@neno-is-ooo/mcp-openverse/badge" alt="@mcp/openverse MCP server" />
+</a>
+
 ## Features
 
 - 🔍 Search for CC-licensed and public domain images


### PR DESCRIPTION
This PR adds a badge for the [@mcp/openverse](https://glama.ai/mcp/servers/@neno-is-ooo/mcp-openverse) server listing in Glama MCP server directory.

<a href="https://glama.ai/mcp/servers/@neno-is-ooo/mcp-openverse">
  <img width="380" height="200" src="https://glama.ai/mcp/servers/@neno-is-ooo/mcp-openverse/badge" alt="@mcp/openverse MCP server" />
</a>

Glama performs regular codebase and documentation checks to:

* Confirm that the MCP server is working as expected
* Confirm that there are no obvious security issues with dependencies of the server
* Extract server characteristics such as tools, resources, prompts, and required parameters.

This badge helps your users to quickly assess that the MCP server is safe, server capabilities, and instructions for installing the server.